### PR TITLE
Allow closing server via signal on /exit

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,7 +58,11 @@ color-eyre = "*"
 lipsum = "0.8.2"
 
 tower = "0.4"
-semver =  { version = "1.0", features = ["serde"] }
+semver = { version = "1.0", features = ["serde"] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.26", features = ["signal"] }
+
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/core/src/server.rs
+++ b/core/src/server.rs
@@ -1,12 +1,13 @@
 use std::net::SocketAddr;
 
-use axum::{routing::get, Extension, Router, response::IntoResponse};
+use axum::routing::post;
+use axum::{response::IntoResponse, routing::get, Extension, Router};
 use tokio::sync::oneshot;
 use tracing::info;
 
 use crate::{config::Config, control_center::ControlCenterHandle, websocket};
+use semver::Version;
 use tower::ServiceBuilder;
-use semver::{Version};
 
 /// The default port to run the server on.
 pub const DEFAULT_PORT: u16 = 3123;
@@ -20,13 +21,13 @@ async fn run(config: Config, port: Option<u16>, allocated_port: Option<oneshot::
         .route("/client", get(websocket::ws_handler))
         .route("/config", get(show_config))
         .route("/version", get(show_version))
+        .route("/exit", post(exit_server))
         .layer(
             ServiceBuilder::new()
                 // Each websocket needs to be able to reach the control center
                 .layer(Extension(cc_handle))
-
                 // The serial-keel config should be known to the web server
-                .layer(Extension(config.clone()))
+                .layer(Extension(config.clone())),
         );
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port.unwrap_or(0)));
@@ -56,11 +57,26 @@ pub async fn run_on_port(config: Config, port: u16) {
     run(config, Some(port), None).await
 }
 
+#[cfg(unix)]
+async fn exit_server() {
+    use nix::sys::signal;
+    use nix::unistd::Pid;
+
+    // The server has a graceful handler for SIGHUP.
+    _ = nix::sys::signal::kill(Pid::this(), signal::Signal::SIGHUP);
+}
+
+#[cfg(not(unix))]
+async fn exit_server() {
+    // Not supported yet
+}
+
 async fn show_config(Extension(config): Extension<Config>) -> impl IntoResponse {
-    return config.serialize_pretty()
+    config.serialize_pretty()
 }
 
 async fn show_version() -> impl IntoResponse {
-    let version = Version::parse(env!("CARGO_PKG_VERSION")).expect("The server version should always be semver parsable!");
-    return serde_json::to_string_pretty(&version).unwrap()
+    let version = Version::parse(env!("CARGO_PKG_VERSION"))
+        .expect("The server version should always be semver parsable!");
+    serde_json::to_string_pretty(&version).unwrap()
 }


### PR DESCRIPTION
The use case is that if we run `serial-keel &` (in the background) for example on CI, we want to be able to easily close it.
Therefore expose `/exit`.

Some minor cleanup too.