### PR TITLE
Some cleanup

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -50,7 +50,7 @@ impl Group {
     }
 
     /// Make a group where the group itself has some label.
-    fn new_with_labels<S: AsRef<str>>(labels: &[S], endpoints: Vec<EndpointId>) -> Self {
+    pub fn new_with_labels<S: AsRef<str>>(labels: &[S], endpoints: Vec<EndpointId>) -> Self {
         Self {
             labels: Labels::from_iter(labels),
             endpoints: endpoints.into_iter().map(Into::into).collect(),

--- a/core/src/endpoint.rs
+++ b/core/src/endpoint.rs
@@ -300,15 +300,18 @@ impl Labels {
         self.0.iter()
     }
 
-    pub(crate) fn is_superset(&self, other: &Labels) -> bool {
+    /// Check if these labels are a superset of some other labels.
+    pub fn is_superset(&self, other: &Labels) -> bool {
         self.as_hash_set().is_superset(&other.as_hash_set())
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
+    /// Check if the labels collection is empty.
+    pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
-    pub(crate) fn push<S>(&mut self, label: S)
+    /// Push a new label.
+    pub fn push<S>(&mut self, label: S)
     where
         S: AsRef<str>,
     {

--- a/frontend/iced/src/main.rs
+++ b/frontend/iced/src/main.rs
@@ -1,5 +1,3 @@
-use std::net::Ipv4Addr;
-
 use iced::{
     executor, widget::Column, Application, Command, Element, Settings, Subscription, Theme,
 };

--- a/frontend/iced/src/servers.rs
+++ b/frontend/iced/src/servers.rs
@@ -1,3 +1,6 @@
+// TODO: Remove when fate of frontend-iced is sealed
+#![allow(dead_code)]
+
 use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr},
@@ -219,7 +222,7 @@ impl ServersPaneState {
             return elements::empty("No server selected");
         };
 
-        let server = state.servers.get(server_id).unwrap();
+        let _server = state.servers.get(server_id).unwrap();
 
         elements::empty("hi")
     }
@@ -324,7 +327,7 @@ impl ServersTab {
                 self.show_connect_modal = false;
             }
             ServersTabMessage::TryConnect(server_id) => {
-                dbg!("Want to connect to {server_id:?}");
+                dbg!("Want to connect to", server_id);
             }
             ServersTabMessage::ConnectIpChanged(ip) => {
                 self.connect_modal_state.set_ip(Some(ip));

--- a/frontend/iced/src/subscriptions.rs
+++ b/frontend/iced/src/subscriptions.rs
@@ -1,8 +1,8 @@
-use iced::{futures::stream::BoxStream, subscription};
-use serial_keel::{client::EventReader, events::TimestampedEvent};
+// use iced::{futures::stream::BoxStream, subscription};
+// use serial_keel::{client::EventReader, events::TimestampedEvent};
 
-#[derive(Debug)]
-struct SerialKeelEvents(EventReader);
+// #[derive(Debug)]
+// struct SerialKeelEvents(EventReader);
 
 // Check the websocket example (and the iced PR that added it) for mpsc tips.
 


### PR DESCRIPTION
- Fixes `wrong thing` log loop if a client loses connection to a server
- Exposes some functions as pub for downstream consumers
- Cleans up some logging
- Use `ControlCenterHandle` where appropriate
- Fixes some warnings