### PR TITLE
Misc improvements

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ This grants the user access as soon as any match is available.
 Ports may also be grouped.
 Gaining control over any port in a group means control over all of them.
 """
-version = "0.1.0"
+version = "0.1.0-alpha-1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/core/src/bin/mock-session.rs
+++ b/core/src/bin/mock-session.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
     writer.write("Hello\nWorld\nBye!").await?;
 
     for _ in 0..3 {
-        let msg = observer.next_message().await;
+        let msg = observer.next_message().await?;
         info!("{msg}");
     }
 

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -91,8 +91,15 @@ impl EndpointReader {
     }
 
     /// Await the next message from the endpoint.
-    pub async fn next_message(&mut self) -> SerialMessage {
-        String::from_utf8_lossy(&self.messages.next().await.unwrap()).into()
+    pub async fn next_message(&mut self) -> Result<SerialMessage, Error> {
+        let message = self.messages.next().await.ok_or_else(|| {
+            Error::InternalIssue(format!(
+                "No more messages on endpoint {}",
+                self.endpoint_id()
+            ))
+        })?;
+
+        Ok(String::from_utf8_lossy(&message).into())
     }
 
     /// Get the next message if there is one.

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -178,7 +178,7 @@ impl EndpointWriter {
 
 /// A collection of [`EndpointWriter`].
 #[derive(Debug)]
-pub struct EndpointWriters(Vec<EndpointWriter>);
+pub struct EndpointWriters(pub Vec<EndpointWriter>);
 
 impl Display for EndpointWriters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -87,6 +87,10 @@ pub struct Config {
     /// See [`Group`].
     // TODO: Use Option<..> to allow omitting in config
     pub groups: Vec<Group>,
+
+    /// When starting the server, if any listed endpoint cannot be opened,
+    /// continue with a warning instead of quitting
+    pub ignore_unavailable_endpoints: bool,
 }
 
 impl Config {
@@ -128,6 +132,7 @@ impl Config {
                     labels: Labels::default(),
                 },
             ],
+            ignore_unavailable_endpoints: false,
         }
     }
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -278,7 +278,7 @@ mod tests {
             ],
         ),
     ],
-    auto_open_serial_ports: true,
+    ignore_unavailable_endpoints: true,
 )
 "#;
         let _config = Config::deserialize(input);

--- a/core/src/control_center.rs
+++ b/core/src/control_center.rs
@@ -454,7 +454,19 @@ impl ControlCenter {
                     }
 
                     let id = InternalEndpointId::Tty(tty);
-                    endpoints.insert(id, builder.build());
+
+                    let endpoint = match builder.build() {
+                        Ok(e) => e,
+                        Err(e) if config.ignore_unavailable_endpoints => {
+                            warn!("Ignoring bad serial port: {e:#?}");
+                            continue;
+                        }
+                        Err(e) => {
+                            panic!("Serial port issue: {e:#?}")
+                        }
+                    };
+
+                    endpoints.insert(id, endpoint);
                 }
                 EndpointId::Mock(mock) => {
                     let mock_id = MockId::new("MockFromConfig", &mock);
@@ -512,7 +524,19 @@ impl ControlCenter {
                     }
 
                     let id = InternalEndpointId::Tty(tty_path.into());
-                    endpoints.insert(id, builder.build());
+
+                    let endpoint = match builder.build() {
+                        Ok(e) => e,
+                        Err(e) if config.ignore_unavailable_endpoints => {
+                            warn!("Ignoring bad serial port: {e:#?}");
+                            continue;
+                        }
+                        Err(e) => {
+                            panic!("Serial port issue: {e:#?}")
+                        }
+                    };
+
+                    endpoints.insert(id, endpoint);
                 }
             }
         }

--- a/core/src/endpoint.rs
+++ b/core/src/endpoint.rs
@@ -139,7 +139,7 @@ impl Hash for InternalEndpointInfo {
 impl Display for InternalEndpointInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if !&self.labels.is_empty() {
-            write!(f, "{}, labels: {}", self.id, self.labels)
+            write!(f, "{} [{}]", self.id, self.labels)
         } else {
             write!(f, "{}", self.id)
         }
@@ -155,7 +155,16 @@ impl InternalEndpointInfo {
 impl Display for InternalEndpointId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InternalEndpointId::Tty(tty) => write!(f, "{tty}"),
+            InternalEndpointId::Tty(tty) => {
+                // Reduce log verbosity
+                let tty = if let Some(tty) = tty.strip_prefix("/dev/serial/by-id/") {
+                    tty
+                } else {
+                    tty
+                };
+
+                write!(f, "{tty}")
+            }
             InternalEndpointId::Mock(mock_id) => {
                 write!(f, "{mock_id}")
             }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -203,7 +203,7 @@ impl Events {
 
     /// Send an event. This will append it to the log and broadcast it to any subscribers.
     pub fn send_event(&mut self, event: TimestampedEvent) {
-        info!(%event, "Sending and storing event");
+        info!(%event, "Event");
         self.log.push_front(event.clone());
 
         // Keep a log of at most this number recent events.

--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -16,7 +16,7 @@ fn do_init() {
 
     // .unwrap_or_else(|_| LevelFilter::INFO),
     // let layer = tracing_subscriber::fmt::layer().with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
-    let layer = tracing_subscriber::fmt::layer();
+    let layer = tracing_subscriber::fmt::layer().pretty();
     let registry = registry.with(layer.with_filter(filter));
 
     #[cfg(feature = "use-tracy")]

--- a/core/src/serial.rs
+++ b/core/src/serial.rs
@@ -40,7 +40,7 @@ impl<T: AsRef<str>> From<T> for SerialMessage {
 
 impl Display for SerialMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        const LEN: usize = 16;
+        const LEN: usize = 48;
 
         let s = if self.0.len() > LEN {
             &self.0[0..LEN]

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -8,7 +8,6 @@ mod common;
 
 #[tokio::test]
 async fn can_use_mock() -> Result<()> {
-
     let port = start_server().await;
 
     let mut client = ClientHandle::new("localhost", port).await?;
@@ -39,11 +38,11 @@ async fn can_use_mock() -> Result<()> {
     let (m1, m2) = message.split_once('\n').unwrap();
 
     debug!(%mock_1,  "Next message");
-    let received = observing.next_message().await;
+    let received = observing.next_message().await?;
     assert_eq!(m1, received.as_str());
 
     debug!(%mock_1,  "Next message");
-    let received = observing.next_message().await;
+    let received = observing.next_message().await?;
     assert_eq!(m2, received.as_str());
 
     drop(client);

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -86,6 +86,7 @@ pub async fn start_server_with_group(group: Group) -> u16 {
     start_server_with_config(Config {
         groups: vec![group],
         endpoints: vec![],
+        ignore_unavailable_endpoints: false,
     })
     .await
 }

--- a/core/tests/regression_tests/several_mocks_want_same_group_write_big_message/mock.ron
+++ b/core/tests/regression_tests/several_mocks_want_same_group_write_big_message/mock.ron
@@ -28,4 +28,5 @@
             ],
         )
     ],
+    ignore_unavailable_endpoints: false,
 )

--- a/core/tests/regression_tests/several_mocks_want_same_group_write_big_message/mod.rs
+++ b/core/tests/regression_tests/several_mocks_want_same_group_write_big_message/mod.rs
@@ -33,7 +33,7 @@ async fn run_a_client(port: u16) -> Result<()> {
 
     // 4.
     loop {
-        let msg = observer.next_message().await;
+        let msg = observer.next_message().await?;
         if msg.as_str().contains("Entering standby") {
             break;
         }
@@ -44,7 +44,6 @@ async fn run_a_client(port: u16) -> Result<()> {
 
 #[tokio::test]
 async fn test() -> Result<()> {
-
     let config = Config::deserialize(include_str!("mock.ron"));
     let port = common::start_server_with_config(config).await;
 

--- a/py/examples/test_mock_concurrent.ron
+++ b/py/examples/test_mock_concurrent.ron
@@ -22,5 +22,5 @@
         ),
     ],
     groups: [],
+    ignore_unavailable_endpoints: false,
 )
-


### PR DESCRIPTION
* Allow clients to access endpoint writers
* Allow the server to ignore bad serial ports when starting
* Allow users to react to readers not getting new messages (happens if client is gone while reader is alive)
* Make logging slightly better when events are received
* `/version` endpoint now states `alpha-1`, a number we can linearly increase before a tagged release is made