### PR TITLE
Fix cargo not found during upgrade

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ This grants the user access as soon as any match is available.
 Ports may also be grouped.
 Gaining control over any port in a group means control over all of them.
 """
-version = "0.1.0-alpha-2"
+version = "0.1.0-alpha-3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/scripts/systemd/check_and_upgrade_serial_keel.sh
+++ b/scripts/systemd/check_and_upgrade_serial_keel.sh
@@ -11,6 +11,8 @@ CONFIG_PATH=${2-$HOME/config.ron}
 SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 cd $SCRIPT_PATH
 
+source $HOME/.cargo/env
+
 # If we happen to run this script for the first time, then we call the install script
 if ! test -f "$HOME/.config/systemd/user/serial-keel.service"; then
     echo "We happen to be running the upgrade script before we've had a first time install.."


### PR DESCRIPTION
Fix cargo not being found during an automatic serial-keel upgrade