### PR TITLE
Separate stdout logging and file logging

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -60,6 +60,7 @@ lipsum = "0.8.2"
 
 tower = "0.4"
 semver = { version = "1.0", features = ["serde"] }
+tracing-appender = "0.2.2"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26", features = ["signal"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ This grants the user access as soon as any match is available.
 Ports may also be grouped.
 Gaining control over any port in a group means control over all of them.
 """
-version = "0.1.0-alpha-5"
+version = "0.1.0-alpha-6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/core/src/bin/mock-client.rs
+++ b/core/src/bin/mock-client.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use color_eyre::Result;
 use lipsum::lipsum_words;
 use serial_keel::client::ClientHandle;
-use tracing::{error, info};
+use tracing::{error, info, Level};
 
 /// Mocks a client for testing purposes.
 /// Sends/receives messages to/from a server at the given address at the given rates.
@@ -51,7 +51,7 @@ async fn run(args: Args) -> Result<()> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    serial_keel::logging::init().await;
+    serial_keel::logging::init(Level::INFO, None).await;
 
     let args = Args::parse();
 

--- a/core/src/bin/mock-session.rs
+++ b/core/src/bin/mock-session.rs
@@ -1,10 +1,10 @@
 use color_eyre::Result;
 use serial_keel::client::ClientHandle;
-use tracing::info;
+use tracing::{info, Level};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    serial_keel::logging::init().await;
+    serial_keel::logging::init(Level::INFO, None).await;
 
     let mut client = ClientHandle::new("127.0.0.1", 3123).await?;
 

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use serde::Serialize;
+use tracing::Level;
 
 use crate::{
     actions::{self, Action},
@@ -16,6 +17,20 @@ use crate::{
 pub struct Cli {
     /// Path to a configuration file
     pub config: Option<PathBuf>,
+
+    /// Which level to log to for stdout
+    #[arg(long, default_value_t = Level::WARN)]
+    pub stdout_log: Level,
+
+    /// Which level to log to for files
+    #[arg(long, default_value_t = Level::INFO)]
+    pub file_log: Level,
+
+    /// Which directory to put log files into.
+    /// Log files rotate daily.
+    /// Will attempt to make the directory if it does not exist.
+    #[arg(long, default_value = "logs")]
+    pub file_dir: PathBuf,
 
     /// Subcommands
     #[command(subcommand)]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -17,7 +17,12 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    logging::init().await;
+    let log_dir = &cli.file_dir;
+    if !log_dir.exists() {
+        _ = std::fs::create_dir_all(log_dir);
+    }
+
+    logging::init(cli.stdout_log, Some((cli.file_log, cli.file_dir))).await;
 
     let config = if let Some(config_path) = cli.config {
         debug!(?config_path, "Config from path");


### PR DESCRIPTION
Fixes #28 

Now, by default stdout receives `WARN` and above messages.
These are the messages critical for knowing the status of the SK server.
If something happens there, we can check the timestamp and dig deeper.

Digging deeper can now be done by checking log files, which by default log at `INFO`.
By default, these files are put into `logs/sk.log.<date>` and rotate file daily.