### PR TITLE
Endpoints may individually set flow control, or default to none

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -7,14 +7,30 @@ on:
 name: Serial Keel - CI
 
 jobs:
-  build_and_test:
+  build_and_test_win_macos:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
+      - name: cargo build
+        run: cargo build --bin serial-keel --all-features
+      - name: cargo test
+        run: cargo test --all-features
+
+  build_and_test_unix:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev
       - name: cargo build
         run: cargo build --bin serial-keel --all-features
       - name: cargo test
@@ -25,6 +41,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev
       - name: clippy
         run: cargo clippy --bin serial-keel --all-features
 
@@ -35,6 +54,9 @@ jobs:
       RUSTDOCFLAGS: '-D warnings'
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libudev-dev
       - name: cargo doc
         run: cargo doc --all-features
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ This grants the user access as soon as any match is available.
 Ports may also be grouped.
 Gaining control over any port in a group means control over all of them.
 """
-version = "0.1.0-alpha-6"
+version = "0.1.0-alpha-7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
@@ -47,6 +47,7 @@ opentelemetry-zipkin = { version = "0.16", features = [
 tokio-util = { version = "0.7", features = ["full"] }
 bytes = "1"
 tokio-serial = "5"
+serialport = { version = "4.2.0", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 ron = "0.8"
 itertools = "0.10"

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -32,6 +32,7 @@ impl From<EndpointId> for ConfigEndpoint {
         Self {
             id: endpoint_id,
             labels: Labels::default(),
+            flow_control: None,
         }
     }
 }
@@ -74,6 +75,11 @@ pub struct ConfigEndpoint {
     /// An optional label for this endpoint.
     /// See [`Label`].
     pub labels: Labels,
+
+    /// Which type of flow control this endpoint should use.
+    /// Only used by non-mocked endpoints.
+    /// Defaults to none if not given.
+    pub flow_control: Option<serialport::FlowControl>,
 }
 
 /// The configuration used for running the server.
@@ -126,10 +132,12 @@ impl Config {
                 ConfigEndpoint {
                     id: EndpointId::Tty("COM1".into()),
                     labels: Labels::from_iter([Label::new("device-type-1")]),
+                    flow_control: Some(serialport::FlowControl::Hardware),
                 },
                 ConfigEndpoint {
                     id: EndpointId::Mock("Mock1".into()),
                     labels: Labels::default(),
+                    flow_control: None,
                 },
             ],
             ignore_unavailable_endpoints: false,

--- a/core/src/control_center.rs
+++ b/core/src/control_center.rs
@@ -454,11 +454,15 @@ impl ControlCenter {
         for ConfigEndpoint {
             id: endpoint_id,
             labels,
+            flow_control,
         } in config.endpoints
         {
             match endpoint_id {
                 EndpointId::Tty(tty) => {
                     let mut builder = SerialPortBuilder::new(&tty);
+
+                    let flow_control = flow_control.unwrap_or(serialport::FlowControl::None);
+                    builder.set_flow_control(flow_control);
 
                     for label in labels.into_iter() {
                         builder = builder.add_label(label);

--- a/core/tests/labels.rs
+++ b/core/tests/labels.rs
@@ -28,6 +28,7 @@ async fn can_control_label() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("Mock1".into()),
         labels: label.into(),
+        flow_control: None,
     });
 
     let mut client = connect(start_server_with_config(config).await).await?;
@@ -46,10 +47,12 @@ async fn two_labelled_endpoints_and_two_users_means_no_queue() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("Mock1".into()),
         labels: label.into(),
+        flow_control: None,
     });
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("Mock2".into()),
         labels: label.into(),
+        flow_control: None,
     });
 
     let port = start_server_with_config(config).await;
@@ -73,10 +76,12 @@ async fn two_labelled_endpoints_and_one_user() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("Mock1".into()),
         labels: label.into(),
+        flow_control: None,
     });
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("Mock2".into()),
         labels: label.into(),
+        flow_control: None,
     });
 
     let port = start_server_with_config(config).await;
@@ -101,6 +106,7 @@ async fn two_labelled_endpoints_can_still_use_specific_names() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: mock1.clone(),
         labels: Labels::from_iter([&label]),
+        flow_control: None,
     });
     let lmock1 = LabelledEndpointId {
         id: mock1.clone(),
@@ -111,6 +117,7 @@ async fn two_labelled_endpoints_can_still_use_specific_names() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: mock2.clone(),
         labels: label.into(),
+        flow_control: None,
     });
 
     let port = start_server_with_config(config).await;
@@ -140,10 +147,12 @@ async fn can_control_different_labels() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("ccdl-Mock1".into()),
         labels: label_1.into(),
+        flow_control: None,
     });
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("ccdl-Mock2".into()),
         labels: label_2.into(),
+        flow_control: None,
     });
 
     let port = start_server_with_config(config).await;
@@ -166,6 +175,7 @@ async fn granted_labelled_endpoint_is_freed_when_user_drops() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("sd".into()),
         labels: Labels::from_iter([label]),
+        flow_control: None,
     });
     let port = start_server_with_config(config).await;
     let mut client_1 = connect(port).await?;
@@ -195,6 +205,7 @@ async fn user_is_informed_of_endpoint_labels() -> Result<()> {
         endpoints: vec![ConfigEndpoint {
             id: EndpointId::mock("glmock"),
             labels: Labels::from_iter([endpoint_label.clone()]),
+            flow_control: None,
         }],
     });
 
@@ -230,6 +241,7 @@ async fn multiple_label_endpoint_is_found_via_subset() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("MockManyLabels".into()),
         labels: Labels::from_iter([label_1, label_2]),
+        flow_control: None,
     });
 
     let mut client = connect(start_server_with_config(config).await).await?;
@@ -250,6 +262,7 @@ async fn multiple_label_endpoint_is_found_via_equal_set() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("MockManyLabels2".into()),
         labels: Labels::from_iter([label_1, label_2]),
+        flow_control: None,
     });
 
     let mut client = connect(start_server_with_config(config).await).await?;
@@ -274,6 +287,7 @@ async fn single_label_endpoint_is_not_matched_via_superset() -> Result<()> {
     config.endpoints.push(ConfigEndpoint {
         id: EndpointId::Mock("MockManyLabels3".into()),
         labels: label_2.into(),
+        flow_control: None,
     });
 
     let mut client = connect(start_server_with_config(config).await).await?;


### PR DESCRIPTION
Since the config option is wrapped in `Option`, old configs should still work.

Serial ports can now set flow control in the config on a per-port basis.
Also change the default flow control from hardware to none.

Fixes #37 